### PR TITLE
Add ZincConfiguration to list of providers

### DIFF
--- a/rules/ext/phase_zinc_compile_ext.bzl
+++ b/rules/ext/phase_zinc_compile_ext.bzl
@@ -9,15 +9,17 @@ load(
 load(
     "@phase_zinc//rules:providers.bzl",
     _ScalaConfiguration = "ScalaConfiguration",
+    _ZincConfiguration = "ZincConfiguration",
 )
 
 ext_zinc_compile = {
     "attrs": {
         "scala": attr.label(
             default = "//external:default_scala",
-            doc = "The `ScalaConfiguration`. Among other things, this specifies which scala version to use.\n Defaults to the default_scala target specified in the WORKSPACE file.",
+            doc = "The `ScalaConfiguration`. Among other things, this specifies which scala version to use.\n Defaults to the default_scala target specified in the WORKSPACE file.\n Also includes ZincConfiguration data.",
             providers = [
                 _ScalaConfiguration,
+                _ZincConfiguration,
             ],
         ),
     },


### PR DESCRIPTION
The `default_scala` target in `WORKSPACE` is designed to serve up both `ScalaConfiguration` and `ZincConfiguration`, but only the Scala one is explicitly provided in the `ext_zinc_compile` dictionary in `phase_zinc_compile_ext.bzl`. Now, we make them both provided.